### PR TITLE
fix: remove error text

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ export default class PDF2Pic {
             return reject(error)
           }
 
-          return resolve(data)
+          return resolve(data.replace(/^[\w\W]+?1/,'1'))
         })
       } else {
         image.identify((error, data) => {


### PR DESCRIPTION
### while there's error, the result looks like:
```
**** Error: File has unbalanced q/Q operators (too many q's)
               Output may be incorrect.
1 2 3 4 5 6 7 8 9
```
this will affect the result of page count.
### after remove error, the result looks like:
```
1 2 3 4 5 6 7 8 9
```